### PR TITLE
Add step to install `jasmine-node`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Node uses [Jamine](http://jasmine.github.io/1.3/introduction.html) for testing.
 
 ```
 npm install
+npm install jasmine-node
 npm test
 ```
 


### PR DESCRIPTION
I followed the setup/test instructions for using Node, and I got the following error:

```
$ npm test

> amazing@0.1.0 test /Users/eprice/ThirdParty/amazing
> jasmine-node src/test/node

sh: jasmine-node: command not found
npm ERR! weird error 127
npm ERR! not ok code 0
```

I was able to solve it by manually installing `jasmine-node`:

```
$ npm install jasmine-node
npm http GET https://registry.npmjs.org/jasmine-node
npm http 200 https://registry.npmjs.org/jasmine-node
  [...]
jasmine-node@1.14.3 node_modules/jasmine-node
├── mkdirp@0.3.5
├── walkdir@0.0.7
├── coffee-script@1.7.1
├── requirejs@2.1.11
├── jasmine-reporters@0.4.0
├── jasmine-growl-reporter@0.0.2 (growl@1.7.0)
└── gaze@0.3.4 (minimatch@0.2.14, fileset@0.1.5)
eprice-mac:~/ThirdParty/amazing : master
$ npm test

> amazing@0.1.0 test /Users/eprice/ThirdParty/amazing
> jasmine-node src/test/node

...

Finished in 0.006 seconds
3 tests, 5 assertions, 0 failures, 0 skipped
```
